### PR TITLE
Enable breakpoints in Zen C files

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
         "configuration": "./language-configuration.json"
       }
     ],
+    "breakpoints": [
+      {
+        "language": "zenc"
+      }
+    ],
     "grammars": [
       {
         "language": "zenc",


### PR DESCRIPTION
I am opening a pull request for Zen C this weekend for https://github.com/z-libs/Zen-C/issues/289 and to enable people to use that, this extension need to be updated to allow setting breakpoints in Zen C source files.